### PR TITLE
Device number issue

### DIFF
--- a/VoiceCommand/voicecommand.cpp
+++ b/VoiceCommand/voicecommand.cpp
@@ -824,7 +824,7 @@ void VoiceCommand::Setup() {
         int card = -1,device = -1;
         cmd = popen("arecord -l | awk '/^card [0-9]/ {print $2}'","r");
         fscanf(cmd, "%d:",&card);
-        cmd = popen("arecord -l | awk '/device [0-9]/ {print $2}'","r");
+        cmd = popen("arecord -l | grep -o 'device [0-9]:' | grep -o  '[0-9]:'","r");
         fscanf(cmd, "%d:",&device);
         if(card == -1 || device == -1) {
             printf("I couldn't find a hardware device. You don't have a valid microphone\n");


### PR DESCRIPTION
The device number could be in the same string as the card number.

Ex: "card 1: U0x46d0x802 [USB Device 0x46d:0x802], device 0: USB Audio [USB Audio]"

So awk returns the same string and {print $2} returns the same number as 

awk '/^card [0-9]/ {print $2}'

grep -o returns the device number properly.
